### PR TITLE
replaced $vmSwitch.$NetAdapterNames with $vmSwitch.NetAdapterNames

### DIFF
--- a/api/vm_switch.go
+++ b/api/vm_switch.go
@@ -150,7 +150,7 @@ Get-Vm | Out-Null
 $vmSwitch = '{{.VmSwitchJson}}' | ConvertFrom-Json
 $minimumBandwidthMode = [Microsoft.HyperV.PowerShell.VMSwitchBandwidthMode]$vmSwitch.BandwidthReservationMode
 $switchType = [Microsoft.HyperV.PowerShell.VMSwitchType]$vmSwitch.SwitchType
-$NetAdapterNames = @($vmSwitch.$NetAdapterNames)
+$NetAdapterNames = @($vmSwitch.NetAdapterNames)
 #when EnablePacketDirect=true it seems to throw an exception if EnableIov=true or EnableEmbeddedTeaming=true
 
 $switchObject = Get-VMSwitch | ?{$_.Name -eq $vmSwitch.Name}
@@ -289,7 +289,7 @@ Get-Vm | Out-Null
 $vmSwitch = '{{.VmSwitchJson}}' | ConvertFrom-Json
 $minimumBandwidthMode = [Microsoft.HyperV.PowerShell.VMSwitchBandwidthMode]$vmSwitch.BandwidthReservationMode
 $switchType = [Microsoft.HyperV.PowerShell.VMSwitchType]$vmSwitch.SwitchType
-$NetAdapterNames = @($vmSwitch.$NetAdapterNames)
+$NetAdapterNames = @($vmSwitch.NetAdapterNames)
 #when EnablePacketDirect=true it seems to throw an exception if EnableIov=true or EnableEmbeddedTeaming=true
 
 $switchObject = Get-VMSwitch | ?{$_.Name -eq $vmSwitch.Name}

--- a/hyperv/resource_hyperv_machine_instance.go
+++ b/hyperv/resource_hyperv_machine_instance.go
@@ -17,6 +17,19 @@ func resourceHyperVMachineInstance() *schema.Resource {
 		Update: resourceHyperVMachineInstanceUpdate,
 		Delete: resourceHyperVMachineInstanceDelete,
 
+		Importer: &schema.ResourceImporter{
+			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				// d.Id() here is the last argument passed to the `terraform import RESOURCE_TYPE.RESOURCE_NAME RESOURCE_ID` command
+				/*
+						The `resourceHyperVMachineInstanceRead` function
+					appears to use the `name` attribute to uniquely identify
+					the VM.  So this just sets the value of the `name`
+					attribute to the supplied RESOURCE_ID.
+				*/
+				d.Set("name", d.Id())
+				return []*schema.ResourceData{d}, nil
+			},
+		},
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,

--- a/hyperv/resource_hyperv_network_switch.go
+++ b/hyperv/resource_hyperv_network_switch.go
@@ -16,6 +16,19 @@ func resourceHyperVNetworkSwitch() *schema.Resource {
 		Update: resourceHyperVNetworkSwitchUpdate,
 		Delete: resourceHyperVNetworkSwitchDelete,
 
+		Importer: &schema.ResourceImporter{
+			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				// d.Id() here is the last argument passed to the `terraform import RESOURCE_TYPE.RESOURCE_NAME RESOURCE_ID` command
+				/*
+						The `resourceHyperVNetworkSwitchRead` appears to use
+					the `name` attribute to uniquely identify the switch.  So
+					this just sets the value of the `name` attribute to the
+					supplied RESOURCE_ID.
+				*/
+				d.Set("name", d.Id())
+				return []*schema.ResourceData{d}, nil
+			},
+		},
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,

--- a/hyperv/resource_hyperv_vhd.go
+++ b/hyperv/resource_hyperv_vhd.go
@@ -16,6 +16,19 @@ func resourceHyperVVhd() *schema.Resource {
 		Update: resourceHyperVVhdUpdate,
 		Delete: resourceHyperVVhdDelete,
 
+		Importer: &schema.ResourceImporter{
+			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				// d.Id() here is the last argument passed to the `terraform import RESOURCE_TYPE.RESOURCE_NAME RESOURCE_ID` command
+				/*
+						The `resourceHyperVVhdRead` function appears to use
+					the `path` attribute to uniquely identify the vhd.  So
+					this just sets the value of the `path` attribute to the
+					supplied RESOURCE_ID.
+				*/
+				d.Set("path", d.Id())
+				return []*schema.ResourceData{d}, nil
+			},
+		},
 		Schema: map[string]*schema.Schema{
 			"path": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
The `CreateVMSwitch` and `UpdateVMSwitch` powershell templates within the `api/vm_switch.go` file were accessing the `NetAdapterNames` property of the `$vmSwitch` variable via `$NetAdapterNames`.  That causes the `net_adapter_names` parameter for `hyperv_network_switch` to not work.

This change fixes that.