### PR TITLE
The CreateVMSwitch and UpdateVMSwitch powershell templates within the…

### DIFF
--- a/api/vm_switch.go
+++ b/api/vm_switch.go
@@ -150,7 +150,7 @@ Get-Vm | Out-Null
 $vmSwitch = '{{.VmSwitchJson}}' | ConvertFrom-Json
 $minimumBandwidthMode = [Microsoft.HyperV.PowerShell.VMSwitchBandwidthMode]$vmSwitch.BandwidthReservationMode
 $switchType = [Microsoft.HyperV.PowerShell.VMSwitchType]$vmSwitch.SwitchType
-$NetAdapterNames = @($vmSwitch.$NetAdapterNames)
+$NetAdapterNames = @($vmSwitch.NetAdapterNames)
 #when EnablePacketDirect=true it seems to throw an exception if EnableIov=true or EnableEmbeddedTeaming=true
 
 $switchObject = Get-VMSwitch | ?{$_.Name -eq $vmSwitch.Name}
@@ -289,7 +289,7 @@ Get-Vm | Out-Null
 $vmSwitch = '{{.VmSwitchJson}}' | ConvertFrom-Json
 $minimumBandwidthMode = [Microsoft.HyperV.PowerShell.VMSwitchBandwidthMode]$vmSwitch.BandwidthReservationMode
 $switchType = [Microsoft.HyperV.PowerShell.VMSwitchType]$vmSwitch.SwitchType
-$NetAdapterNames = @($vmSwitch.$NetAdapterNames)
+$NetAdapterNames = @($vmSwitch.NetAdapterNames)
 #when EnablePacketDirect=true it seems to throw an exception if EnableIov=true or EnableEmbeddedTeaming=true
 
 $switchObject = Get-VMSwitch | ?{$_.Name -eq $vmSwitch.Name}


### PR DESCRIPTION
The `CreateVMSwitch` and `UpdateVMSwitch` powershell templates within the `api/vm_switch.go` file were accessing the `NetAdapterNames` property of the `$vmSwitch` variable via `$NetAdapterNames`.  That causes the `net_adapter_names` parameter for `hyperv_network_switch` to not work.

This change fixes that.