### PR TITLE
Improve performance when there are a large number of VMs on the host

### DIFF
--- a/api/vhd.go
+++ b/api/vhd.go
@@ -155,7 +155,7 @@ type createOrUpdateVhdArgs struct {
 var createOrUpdateVhdTemplate = template.Must(template.New("CreateOrUpdateVhd").Parse(`
 $ErrorActionPreference = 'Stop'
 
-Get-VM | Out-Null
+Import-Module Hyper-V
 $source='{{.Source}}'
 $sourceVm='{{.SourceVm}}'
 $sourceDisk={{.SourceDisk}}

--- a/api/vm.go
+++ b/api/vm.go
@@ -313,7 +313,7 @@ type createVmArgs struct {
 
 var createVmTemplate = template.Must(template.New("CreateVm").Parse(`
 $ErrorActionPreference = 'Stop'
-Get-Vm | Out-Null
+Import-Module Hyper-V
 $vm = '{{.VmJson}}' | ConvertFrom-Json
 $automaticCriticalErrorAction = [Microsoft.HyperV.PowerShell.CriticalErrorAction]$vm.AutomaticCriticalErrorAction
 $automaticStartAction = [Microsoft.HyperV.PowerShell.StartAction]$vm.AutomaticStartAction
@@ -322,7 +322,7 @@ $checkpointType = [Microsoft.HyperV.PowerShell.CheckpointType]$vm.CheckpointType
 $lockOnDisconnect = [Microsoft.HyperV.PowerShell.OnOffState]$vm.LockOnDisconnect
 $allowUnverifiedPaths = $true #Not a property set on the vm object, skips validation when changing path
 
-$vmObject = Get-VM | ?{$_.Name -eq $vm.Name}
+$vmObject = Get-VM -Name $vm.Name -ErrorAction SilentlyContinue
 
 if ($vmObject){
 	throw "VM already exists - $($vm.Name)"
@@ -444,7 +444,7 @@ type getVmArgs struct {
 
 var getVmTemplate = template.Must(template.New("GetVm").Parse(`
 $ErrorActionPreference = 'Stop'
-$vmObject = Get-VM | ?{$_.Name -eq '{{.Name}}' } | %{ @{
+$vmObject = Get-VM -Name '{{.Name}}' -ErrorAction SilentlyContinue | %{ @{
 	Name=$_.Name;
 	Generation=$_.Generation;
 	AutomaticCriticalErrorAction=$_.AutomaticCriticalErrorAction;
@@ -490,7 +490,7 @@ type updateVmArgs struct {
 
 var updateVmTemplate = template.Must(template.New("UpdateVm").Parse(`
 $ErrorActionPreference = 'Stop'
-Get-Vm | Out-Null
+Import-Module Hyper-V
 $vm = '{{.VmJson}}' | ConvertFrom-Json
 $automaticCriticalErrorAction = [Microsoft.HyperV.PowerShell.CriticalErrorAction]$vm.AutomaticCriticalErrorAction
 $automaticStartAction = [Microsoft.HyperV.PowerShell.StartAction]$vm.AutomaticStartAction
@@ -498,7 +498,7 @@ $automaticStopAction = [Microsoft.HyperV.PowerShell.StopAction]$vm.AutomaticStop
 $checkpointType = [Microsoft.HyperV.PowerShell.CheckpointType]$vm.CheckpointType
 $lockOnDisconnect = [Microsoft.HyperV.PowerShell.OnOffState]$vm.LockOnDisconnect
 $allowUnverifiedPaths = $true #Not a property set on the vm object, skips validation when changing path
-$vmObject = Get-VM | ?{$_.Name -eq $vm.Name}
+$vmObject = Get-VM -Name $vm.Name -ErrorAction SilentlyContinue
 
 if (!$vmObject){
 	throw "VM does not exist - $($vm.Name)"
@@ -604,7 +604,7 @@ type deleteVmArgs struct {
 
 var deleteVmTemplate = template.Must(template.New("DeleteVm").Parse(`
 $ErrorActionPreference = 'Stop'
-Get-VM | ?{$_.Name -eq '{{.Name}}'} | Remove-VM -force
+Get-VM -Name '{{.Name}}' -ErrorAction SilentlyContinue | Remove-VM -force
 `))
 
 func (c *HypervClient) DeleteVm(name string) (err error) {

--- a/api/vm_dvd_drive.go
+++ b/api/vm_dvd_drive.go
@@ -64,7 +64,7 @@ type createVmDvdDriveArgs struct {
 
 var createVmDvdDriveTemplate = template.Must(template.New("CreateVmDvdDrive").Parse(`
 $ErrorActionPreference = 'Stop'
-Get-Vm | Out-Null
+Import-Module Hyper-V
 $vmDvdDrive = '{{.VmDvdDriveJson}}' | ConvertFrom-Json
 if (!$vmDvdDrive.Path){
 	$vmDvdDrive.Path = $null
@@ -146,7 +146,7 @@ type updateVmDvdDriveArgs struct {
 
 var updateVmDvdDriveTemplate = template.Must(template.New("UpdateVmDvdDrive").Parse(`
 $ErrorActionPreference = 'Stop'
-Get-Vm | Out-Null
+Import-Module Hyper-V
 $vmDvdDrive = '{{.VmDvdDriveJson}}' | ConvertFrom-Json
 
 $vmDvdDrivesObject = @(Get-VMDvdDrive -VmName '{{.VmName}}' -ControllerLocation {{.ControllerLocation}} -ControllerNumber {{.ControllerNumber}} )

--- a/api/vm_firmware.go
+++ b/api/vm_firmware.go
@@ -196,7 +196,7 @@ type createOrUpdateVmFirmwareArgs struct {
 
 var createOrUpdateVmFirmwareTemplate = template.Must(template.New("CreateOrUpdateVmFirmware").Parse(`
 $ErrorActionPreference = 'Stop'
-Get-Vm | Out-Null
+Import-Module Hyper-V
 $vmFirmware = '{{.VmFirmwareJson}}' | ConvertFrom-Json
 
 $SetVMFirmwareArgs = @{}

--- a/api/vm_hard_disk_drive.go
+++ b/api/vm_hard_disk_drive.go
@@ -223,7 +223,7 @@ type createVmHardDiskDriveArgs struct {
 
 var createVmHardDiskDriveTemplate = template.Must(template.New("CreateVmHardDiskDrive").Parse(`
 $ErrorActionPreference = 'Stop'
-Get-Vm | Out-Null
+Import-Module Hyper-V
 $vmHardDiskDrive = '{{.VmHardDiskDriveJson}}' | ConvertFrom-Json
 
 $NewVmHardDiskDriveArgs = @{
@@ -333,7 +333,7 @@ type updateVmHardDiskDriveArgs struct {
 
 var updateVmHardDiskDriveTemplate = template.Must(template.New("UpdateVmHardDiskDrive").Parse(`
 $ErrorActionPreference = 'Stop'
-Get-Vm | Out-Null
+Import-Module Hyper-V
 $vmHardDiskDrive = '{{.VmHardDiskDriveJson}}' | ConvertFrom-Json
 
 $vmHardDiskDrivesObject = @(Get-VMHardDiskDrive -VmName '{{.VmName}}' -ControllerLocation {{.ControllerLocation}} -ControllerNumber {{.ControllerNumber}} )

--- a/api/vm_network_adapter.go
+++ b/api/vm_network_adapter.go
@@ -334,7 +334,7 @@ type createVmNetworkAdapterArgs struct {
 
 var createVmNetworkAdapterTemplate = template.Must(template.New("CreateVmNetworkAdapter").Parse(`
 $ErrorActionPreference = 'Stop'
-Get-Vm | Out-Null
+Import-Module Hyper-V
 $vmNetworkAdapter = '{{.VmNetworkAdapterJson}}' | ConvertFrom-Json
 
 $dhcpGuard = [Microsoft.HyperV.PowerShell.OnOffState]$vmNetworkAdapter.DhcpGuard
@@ -657,7 +657,7 @@ function Test-IsNotInFinalTransitionState($State){
 function Wait-ForNetworkAdapterIps($Name, $Timeout, $PollPeriod, $VmNetworkAdaptersToWaitForIps){
 	$timer = [Diagnostics.Stopwatch]::StartNew()
 	while ($timer.Elapsed.TotalSeconds -lt $Timeout) {
-        $vmObject = Get-VM | ?{$_.Name -eq $vmName}
+        $vmObject = Get-VM -Name $vmName -ErrorAction SilentlyContinue
 
         if (!(Test-IsNotInFinalTransitionState $vmObject.state)){
             if (Test-CanGetIpsForState $vmObject.state) {
@@ -689,10 +689,10 @@ function Wait-ForNetworkAdapterIps($Name, $Timeout, $PollPeriod, $VmNetworkAdapt
 	} 
 }
 
-Get-Vm | Out-Null
+Import-Module Hyper-V
 $vmNetworkAdaptersToWaitForIps = '{{.VmNetworkAdaptersWaitForIpsJson}}' | ConvertFrom-Json
 $vmName = '{{.VmName}}'
-$vmObject = Get-VM | ?{$_.Name -eq $vmName}
+$vmObject = Get-VM -Name $vmName -ErrorAction SilentlyContinue
 $timeout = {{.Timeout}}
 $pollPeriod = {{.PollPeriod}}
 

--- a/api/vm_processor.go
+++ b/api/vm_processor.go
@@ -123,7 +123,7 @@ type createOrUpdateVmProcessorArgs struct {
 
 var createOrUpdateVmProcessorTemplate = template.Must(template.New("CreateOrUpdateVmProcessor").Parse(`
 $ErrorActionPreference = 'Stop'
-Get-Vm | Out-Null
+Import-Module Hyper-V
 $vmProcessor = '{{.VmProcessorJson}}' | ConvertFrom-Json
 
 $SetVMProcessorArgs = @{}

--- a/api/vm_state.go
+++ b/api/vm_state.go
@@ -153,7 +153,7 @@ var getVmStateTemplate = template.Must(template.New("GetVmState").Parse(`
 $ErrorActionPreference = 'Stop'
 $vmName = '{{.VmName}}'
 
-$vmStateObject = Get-VM | ?{$_.Name -eq $vmName } | %{ @{
+$vmStateObject = Get-VM -Name $vmName -ErrorAction SilentlyContinue | %{ @{
 	State=$_.State;
 }}
 
@@ -241,11 +241,11 @@ function Wait-IsInFinalTransitionState($Name, $Timeout, $PollPeriod){
 	} 
 }
 
-Get-Vm | Out-Null
+Import-Module Hyper-V
 $vm = '{{.VmStateJson}}' | ConvertFrom-Json
 $vmName = '{{.VmName}}'
 $state = [Microsoft.HyperV.PowerShell.VMState]$vm.State
-$vmObject = Get-VM | ?{$_.Name -eq $vmName}
+$vmObject = Get-VM -Name $vmName -ErrorAction SilentlyContinue
 $timeout = {{.Timeout}}
 $pollPeriod = {{.PollPeriod}}
 
@@ -260,7 +260,7 @@ if ($vmObject.State -ne $state) {
 
     Wait-IsInFinalTransitionState -Name $vmName -Timeout $timeout -PollPeriod $pollPeriod
 
-    $vmObject = Get-VM | ?{$_.Name -eq $vmName}
+    $vmObject = Get-VM -Name $vmName -ErrorAction SilentlyContinue
 
     if ($vmObject.State -eq $state) {
     } elseif ($state -eq [Microsoft.HyperV.PowerShell.VMState]::Running) {

--- a/api/vm_switch.go
+++ b/api/vm_switch.go
@@ -146,14 +146,14 @@ type createVMSwitchArgs struct {
 
 var createVMSwitchTemplate = template.Must(template.New("CreateVMSwitch").Parse(`
 $ErrorActionPreference = 'Stop'
-Get-Vm | Out-Null
+Import-Module Hyper-V
 $vmSwitch = '{{.VmSwitchJson}}' | ConvertFrom-Json
 $minimumBandwidthMode = [Microsoft.HyperV.PowerShell.VMSwitchBandwidthMode]$vmSwitch.BandwidthReservationMode
 $switchType = [Microsoft.HyperV.PowerShell.VMSwitchType]$vmSwitch.SwitchType
 $NetAdapterNames = @($vmSwitch.NetAdapterNames)
 #when EnablePacketDirect=true it seems to throw an exception if EnableIov=true or EnableEmbeddedTeaming=true
 
-$switchObject = Get-VMSwitch | ?{$_.Name -eq $vmSwitch.Name}
+$switchObject = Get-VMSwitch -Name $vmSwitch.Name -ErrorAction SilentlyContinue
 
 if ($switchObject){
 	throw "Switch already exists - $($vmSwitch.Name)"
@@ -176,7 +176,7 @@ if ($NetAdapterNames) {
 }
 New-VMSwitch @NewVmSwitchArgs
 
-$switchObject = Get-VMSwitch | ?{$_.Name -eq $vmSwitch.Name}
+$switchObject = Get-VMSwitch -Name $vmSwitch.Name -ErrorAction SilentlyContinue
 
 if (!$switchObject){
 	throw "Switch does not exist - $($vmSwitch.Name)"
@@ -246,7 +246,7 @@ type getVMSwitchArgs struct {
 
 var getVMSwitchTemplate = template.Must(template.New("GetVMSwitch").Parse(`
 $ErrorActionPreference = 'Stop'
-$vmSwitchObject = Get-VMSwitch | ?{$_.Name -eq '{{.Name}}' } | %{ @{
+$vmSwitchObject = Get-VMSwitch -Name '{{.Name}}' -ErrorAction SilentlyContinue | %{ @{
 	Name=$_.Name;
 	Notes=$_.Notes;
 	AllowManagementOS=$_.AllowManagementOS;
@@ -285,14 +285,14 @@ type updateVMSwitchArgs struct {
 
 var updateVMSwitchTemplate = template.Must(template.New("UpdateVMSwitch").Parse(`
 $ErrorActionPreference = 'Stop'
-Get-Vm | Out-Null
+Import-Module Hyper-V
 $vmSwitch = '{{.VmSwitchJson}}' | ConvertFrom-Json
 $minimumBandwidthMode = [Microsoft.HyperV.PowerShell.VMSwitchBandwidthMode]$vmSwitch.BandwidthReservationMode
 $switchType = [Microsoft.HyperV.PowerShell.VMSwitchType]$vmSwitch.SwitchType
 $NetAdapterNames = @($vmSwitch.NetAdapterNames)
 #when EnablePacketDirect=true it seems to throw an exception if EnableIov=true or EnableEmbeddedTeaming=true
 
-$switchObject = Get-VMSwitch | ?{$_.Name -eq $vmSwitch.Name}
+$switchObject = Get-VMSwitch -Name $vmSwitch.Name -ErrorAction SilentlyContinue
 
 if (!$switchObject){
 	throw "Switch does not exist - $($vmSwitch.Name)"
@@ -381,7 +381,7 @@ type deleteVMSwitchArgs struct {
 
 var deleteVMSwitchTemplate = template.Must(template.New("DeleteVMSwitch").Parse(`
 $ErrorActionPreference = 'Stop'
-Get-VMSwitch | ?{$_.Name -eq '{{.Name}}'} | Remove-VMSwitch -Force
+Get-VMSwitch -Name '{{.Name}}' -ErrorAction SilentlyContinue | Remove-VMSwitch -Force
 `))
 
 func (c *HypervClient) DeleteVMSwitch(name string) (err error) {


### PR DESCRIPTION
Avoid calling Get-VM by itself because this action can take quite a while on hosts which are running many VMs.  Instead, use the -Name parameter with -ErrorAction SilentlyContinue (in case of null).

Also use the Import-Module cmdlet to ensure classes are loaded instead of calling Get-VM.