### PR TITLE
fix: Bunch of small fixes

### DIFF
--- a/api/hyperv-winrm/vhd.go
+++ b/api/hyperv-winrm/vhd.go
@@ -50,6 +50,16 @@ $sourceDisk={{.SourceDisk}}
 $vhd = '{{.VhdJson}}' | ConvertFrom-Json
 $vhdType = [Microsoft.Vhd.PowerShell.VhdType]$vhd.VhdType
 
+function Get-TarPath {
+	if (Get-Command "tar" -ErrorAction SilentlyContinue) {
+		return "tar"
+	} elseif (test-path "$env:SystemRoot\system32\tar.exe") {
+		return "$env:SystemRoot\system32\tar.exe"
+	} else {
+		return ""
+	}
+}
+
 function Get-7ZipPath {
 	if (Get-Command "7z" -ErrorAction SilentlyContinue) {
 		return "7z"
@@ -117,12 +127,16 @@ function Expand-Downloads {
         }
 
         get-item *.box | % {
-			$7zPath = Get-7ZipPath
-			if (-not $7zPath) {
- 				throw "7z.exe needed"
+			$tarPath = Get-TarPath
+			if (-not $tarPath) {
+				throw "tar.exe needed"
 			}
 			$tempPath = join-path $FolderPath "temp"
-			$command = """$7zPath"" x ""$($_.FullName)"" -so | ""$7zPath"" x -aoa -si -ttar -o""$tempPath"""
+
+			if (!(Test-Path $tempPath)) {
+				New-Item -ItemType Directory -Force -Path $tempPath
+			}
+			$command = """$tarPath"" -C ""$tempPath"" -x -f ""$($_.FullName)"""
 			& cmd.exe /C $command
 
 			if (Test-Path "$tempPath\Virtual Hard Disks") {

--- a/api/hyperv-winrm/vhd.go
+++ b/api/hyperv-winrm/vhd.go
@@ -51,13 +51,13 @@ $vhd = '{{.VhdJson}}' | ConvertFrom-Json
 $vhdType = [Microsoft.Vhd.PowerShell.VhdType]$vhd.VhdType
 
 function Get-7ZipPath {
-	if (Get-Command "7z" -ErrorAction SilentlyContinue) { 
-   		return "7z"
+	if (Get-Command "7z" -ErrorAction SilentlyContinue) {
+		return "7z"
 	} elseif (test-path "$env:ProgramFiles\7-Zip\7z.exe") {
 		return "$env:ProgramFiles\7-Zip\7z.exe"
 	} elseif (test-path "${env:ProgramFiles(x86)}\7-Zip\7z.exe") {
 		return "${env:ProgramFiles(x86)}\7-Zip\7z.exe"
-	} else { 
+	} else {
 		return ""
 	}
 }
@@ -186,7 +186,7 @@ function Test-Uri {
 
 if (!(Test-Path -Path $vhd.Path)) {
     $pathDirectory = [System.IO.Path]::GetDirectoryName($vhd.Path)
-	$pathFilename = [System.IO.Path]::GetFileName($vhd.Path)
+    $pathFilename = [System.IO.Path]::GetFileName($vhd.Path)
 
     if (!(Test-Path $pathDirectory)) {
         New-Item -ItemType Directory -Force -Path $pathDirectory
@@ -202,7 +202,7 @@ if (!(Test-Path -Path $vhd.Path)) {
         }
 
         Remove-Item "$pathDirectory\$sourceVm" -Force -Recurse
-		Get-VHD -path $vhd.Path
+        Get-VHD -path $vhd.Path
     } elseif ($source) {
         Push-Location $pathDirectory
         

--- a/api/hyperv-winrm/vhd.go
+++ b/api/hyperv-winrm/vhd.go
@@ -155,7 +155,7 @@ function Get-FileFromUri {
         $req.Method = "HEAD"
         $response = $req.GetResponse()
         $fUri = $response.ResponseUri
-        $filename = [System.IO.Path]::GetFileName($fUri.LocalPath);
+        $filename = [System.IO.Path]::GetFileName($fUri.LocalPath)
         $response.Close()
 
         $destination = (Get-Item -Path ".\" -Verbose).FullName
@@ -166,8 +166,8 @@ function Get-FileFromUri {
         else {
             $destination += '\' + $filename
         }
-        $webclient = New-Object System.Net.webclient
-        $webclient.downloadfile($fUri.AbsoluteUri, $destination)
+        $webclient = New-Object System.Net.WebClient
+        $webclient.DownloadFile($fUri.AbsoluteUri, $destination)
     }
 }
 

--- a/api/hyperv-winrm/vhd.go
+++ b/api/hyperv-winrm/vhd.go
@@ -172,6 +172,12 @@ function Get-FileFromUri {
         $filename = [System.IO.Path]::GetFileName($fUri.LocalPath)
         $response.Close()
 
+        $origExt = [System.IO.Path]::GetExtension($Url)
+        $newExt = [System.IO.Path]::GetExtension($filename)
+        if ($newExt -ne $origExt) {
+            $filename += $origExt
+        }
+
         $destination = (Get-Item -Path ".\" -Verbose).FullName
         if ($FolderPath) { $destination = $FolderPath }
         if ($destination.EndsWith('\')) {

--- a/api/hyperv-winrm/vm.go
+++ b/api/hyperv-winrm/vm.go
@@ -180,7 +180,7 @@ type getVmArgs struct {
 
 var getVmTemplate = template.Must(template.New("GetVm").Parse(`
 $ErrorActionPreference = 'Stop'
-$vmObject = Get-VM -Name '{{.Name}}*' | ?{$_.Name -eq '{{.Name}}' } | %{ @{
+$vmObject = Get-VM -Name '{{.Name}}*' -ErrorAction SilentlyContinue | ?{$_.Name -eq '{{.Name}}' } | %{ @{
 	Name=$_.Name;
 	Path=$_.Path;
 	Generation=$_.Generation;

--- a/internal/provider/resource_hyperv_machine_instance.go
+++ b/internal/provider/resource_hyperv_machine_instance.go
@@ -933,6 +933,11 @@ func resourceHyperVMachineInstanceRead(ctx context.Context, d *schema.ResourceDa
 		return diag.FromErr(err)
 	}
 
+        if !d.IsNewResource() && vm.Name == "" {
+		d.SetId("")
+		return nil
+        }
+
 	if err := d.Set("name", vm.Name); err != nil {
 		return diag.FromErr(err)
 	}


### PR DESCRIPTION
Box files from Vargant are tar archives, but 7-Zip does not handle them right, in particular it does not handle directory path separator correctly on Windows and produces flat filenames like "Virtual Hard Disksubuntu-18.04-amd64.vhdx" instead of directory "Virtual Hard Disks" and a file inside it.

Also, manual removal of VMs from hyper-v causes error in the provider while Terraform allows to gracefully remove it from state and then re-create. So enable this ability.

And small formatting fixes.