### PR TITLE
fix: mac address spoofing wasn't set

### DIFF
--- a/api/hyperv-winrm/vm_network_adapter.go
+++ b/api/hyperv-winrm/vm_network_adapter.go
@@ -25,6 +25,7 @@ $iovInterruptModeration = [Microsoft.HyperV.PowerShell.IovInterruptModerationVal
 $allowTeaming = [Microsoft.HyperV.PowerShell.OnOffState]$vmNetworkAdapter.AllowTeaming
 $deviceNaming = [Microsoft.HyperV.PowerShell.OnOffState]$vmNetworkAdapter.DeviceNaming
 $fixSpeed10G = [Microsoft.HyperV.PowerShell.OnOffState]$vmNetworkAdapter.FixSpeed10G
+$macAddressSpoofing = [Microsoft.HyperV.PowerShell.OnOffState]$vmNetworkAdapter.MacAddressSpoofing
 
 $NewVmNetworkAdapterArgs = @{
 	VmName=$vmNetworkAdapter.VmName
@@ -52,9 +53,7 @@ if ($vmNetworkAdapter.DynamicMacAddress) {
 } elseif ($vmNetworkAdapter.StaticMacAddress) {
 	$SetVmNetworkAdapterArgs.StaticMacAddress=$vmNetworkAdapter.StaticMacAddress
 }
-if ($vmNetworkAdapter.MacAddressSpoofing) {
-	$SetVmNetworkAdapterArgs.MacAddressSpoofing=$vmNetworkAdapter.MacAddressSpoofing
-}
+$SetVmNetworkAdapterArgs.MacAddressSpoofing=$macAddressSpoofing
 $SetVmNetworkAdapterArgs.DhcpGuard=$dhcpGuard
 $SetVmNetworkAdapterArgs.RouterGuard=$routerGuard
 $SetVmNetworkAdapterArgs.PortMirroring=$portMirroring
@@ -434,6 +433,7 @@ $iovInterruptModeration = [Microsoft.HyperV.PowerShell.IovInterruptModerationVal
 $allowTeaming = [Microsoft.HyperV.PowerShell.OnOffState]$vmNetworkAdapter.AllowTeaming
 $deviceNaming = [Microsoft.HyperV.PowerShell.OnOffState]$vmNetworkAdapter.DeviceNaming
 $fixSpeed10G = [Microsoft.HyperV.PowerShell.OnOffState]$vmNetworkAdapter.FixSpeed10G
+$macAddressSpoofing = [Microsoft.HyperV.PowerShell.OnOffState]$vmNetworkAdapter.MacAddressSpoofing
 
 $vmNetworkAdaptersObject = @(Get-VMNetworkAdapter -VmName '{{.VmName}}')[{{.Index}}]
 
@@ -457,9 +457,8 @@ if ($vmNetworkAdapter.DynamicMacAddress) {
 } elseif ($vmNetworkAdapter.StaticMacAddress) {
 	$SetVmNetworkAdapterArgs.StaticMacAddress=$vmNetworkAdapter.StaticMacAddress
 }
-if ($vmNetworkAdapter.MacAddressSpoofing) {
-	$SetVmNetworkAdapterArgs.MacAddressSpoofing=$vmNetworkAdapter.MacAddressSpoofing
-}
+
+$SetVmNetworkAdapterArgs.MacAddressSpoofing=$macAddressSpoofing
 $SetVmNetworkAdapterArgs.DhcpGuard=$dhcpGuard
 $SetVmNetworkAdapterArgs.RouterGuard=$routerGuard
 $SetVmNetworkAdapterArgs.PortMirroring=$portMirroring

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 	"github.com/taliesins/terraform-provider-hyperv/internal/provider"

--- a/main.go
+++ b/main.go
@@ -32,6 +32,9 @@ func main() {
 	flag.BoolVar(&debugMode, "debug", false, "set to true to run the provider with support for debuggers like delve")
 	flag.Parse()
 
+	// Remove duplicated timestamp from logs to make them more readable (see: https://developer.hashicorp.com/terraform/plugin/log/writing#legacy-log-troubleshooting)
+	log.SetFlags(log.Flags() &^ (log.Ldate | log.Ltime))
+
 	opts := &plugin.ServeOpts{
 		Debug: debugMode,
 


### PR DESCRIPTION
The property network_adaptors.mac_address_spoofing wasn't set during apply, now it's set properly.

Also removed double timestamps in terraform verbose logs so that logs are easier to read