### PR TITLE
fix: You can now update hyper-v switches and rename them

### DIFF
--- a/api/vm_switch.go
+++ b/api/vm_switch.go
@@ -166,7 +166,8 @@ type HypervVmSwitchClient interface {
 	GetVMSwitch(ctx context.Context, name string) (result VmSwitch, err error)
 	UpdateVMSwitch(
 		ctx context.Context,
-		name string,
+		switchId string,
+		switchName string,
 		notes string,
 		allowManagementOS bool,
 		// embeddedTeamingEnabled bool,

--- a/internal/provider/resource_hyperv_network_switch.go
+++ b/internal/provider/resource_hyperv_network_switch.go
@@ -369,7 +369,9 @@ func resourceHyperVNetworkSwitchUpdate(ctx context.Context, d *schema.ResourceDa
 	log.Printf("[INFO][hyperv][update] updating hyperv switch: %#v", d)
 	c := meta.(api.Client)
 
-	switchName := d.Id()
+	id := d.Id()
+	newName := d.Get("name").(string)
+
 	notes := (d.Get("notes")).(string)
 	allowManagementOS := (d.Get("allow_management_os")).(bool)
 	// embeddedTeamingEnabled := (d.Get("enable_embedded_teaming")).(bool)
@@ -438,11 +440,13 @@ func resourceHyperVNetworkSwitchUpdate(ctx context.Context, d *schema.ResourceDa
 		return diag.Errorf("[ERROR][hyperv][update] defaultQueueVmmqQueuePairs must be greater then 0")
 	}
 
-	err := c.UpdateVMSwitch(ctx, switchName, notes, allowManagementOS, switchType, netAdapterNames, defaultFlowMinimumBandwidthAbsolute, defaultFlowMinimumBandwidthWeight, defaultQueueVmmqEnabled, defaultQueueVmmqQueuePairs, defaultQueueVrssEnabled)
+	err := c.UpdateVMSwitch(ctx, id, newName, notes, allowManagementOS, switchType, netAdapterNames, defaultFlowMinimumBandwidthAbsolute, defaultFlowMinimumBandwidthWeight, defaultQueueVmmqEnabled, defaultQueueVmmqQueuePairs, defaultQueueVrssEnabled)
 
 	if err != nil {
 		return diag.FromErr(err)
 	}
+
+	d.SetId(newName)
 
 	log.Printf("[INFO][hyperv][update] updated hyperv switch: %#v", d)
 


### PR DESCRIPTION
Changing any property of a switch would trigger the error message: "Set-VMSwitch : Cannot convert 'System.Object[]' to the type 'System.String' required by parameter 'NetAdapterName'."
This is solved by: **api/hyperv-winrm/vm_switch.go:193-195** and **api/hyperv-winrm/vm_switch.go:264-266**

Changing the name of a switch would not actually rename the switch. This has also been fixed, but I'm a bit uncertain of the fix on line: **api/vm_switch.go:449**

I noticed when doing this that updating a switch that has NIC teaming configured would fail as Set-VMSwitch doesn't take a array when setting *NetAdapterName*. This has been broken before too