### PR TITLE
refactor: Support packer compression output

### DIFF
--- a/api/hyperv-winrm/vhd.go
+++ b/api/hyperv-winrm/vhd.go
@@ -81,6 +81,7 @@ function Expand-Downloads {
     )
     process {
 		Push-Location $FolderPath
+		$vhdPath = Get-ChildItem $tempPath *"Virtual Hard Disks"* -Recurse -Directory
 
         get-item *.zip | % {
 			$tempPath = join-path $FolderPath "temp"
@@ -97,8 +98,8 @@ function Expand-Downloads {
             	[System.IO.Compression.ZipFile]::ExtractToDirectory($_.FullName, $tempPath)
 			}
 
-            if (Test-Path "$tempPath\Virtual Hard Disks") {
-        		Move-Item "$tempPath\Virtual Hard Disks\*.*" $FolderPath
+            if (Test-Path $($vhdPath.FullName)) {
+        		Move-Item $($vhdPath.FullName)\*.* $FolderPath
 			} else {
 				Move-Item "$tempPath\*.*" $FolderPath
 			}
@@ -116,8 +117,8 @@ function Expand-Downloads {
 			$command = """$7zPath"" x ""$($_.FullName)"" -o""$tempPath""" 
 			& cmd.exe /C $command
 
-			if (Test-Path "$tempPath\Virtual Hard Disks") {
-        		Move-Item "$tempPath\Virtual Hard Disks\*.*" $FolderPath
+			if (Test-Path $($vhdPath.FullName)) {
+        		Move-Item $"($vhdPath.FullName)\*.*" $FolderPath
 			} else {
 				Move-Item "$tempPath\*.*" $FolderPath
 			}
@@ -139,8 +140,8 @@ function Expand-Downloads {
 			$command = """$tarPath"" -C ""$tempPath"" -x -f ""$($_.FullName)"""
 			& cmd.exe /C $command
 
-			if (Test-Path "$tempPath\Virtual Hard Disks") {
-        		Move-Item "$tempPath\Virtual Hard Disks\*.*" $FolderPath
+			if (Test-Path $($vhdPath.FullName)) {
+        		Move-Item "$($vhdPath.FullName)\*.*" $FolderPath
 			} else {
 				Move-Item "$tempPath\*.*" $FolderPath
 			}

--- a/api/hyperv-winrm/vhd.go
+++ b/api/hyperv-winrm/vhd.go
@@ -99,7 +99,7 @@ function Expand-Downloads {
 			}
 
             if (Test-Path $($vhdPath.FullName)) {
-        		Move-Item $($vhdPath.FullName)\*.* $FolderPath
+        		Move-Item "$($vhdPath.FullName)\*.*" $FolderPath
 			} else {
 				Move-Item "$tempPath\*.*" $FolderPath
 			}
@@ -117,8 +117,8 @@ function Expand-Downloads {
 			$command = """$7zPath"" x ""$($_.FullName)"" -o""$tempPath""" 
 			& cmd.exe /C $command
 
-			if (Test-Path $($vhdPath.FullName)) {
-        		Move-Item $"($vhdPath.FullName)\*.*" $FolderPath
+            if (Test-Path $($vhdPath.FullName)) {
+        		Move-Item "$($vhdPath.FullName)\*.*" $FolderPath
 			} else {
 				Move-Item "$tempPath\*.*" $FolderPath
 			}
@@ -140,7 +140,7 @@ function Expand-Downloads {
 			$command = """$tarPath"" -C ""$tempPath"" -x -f ""$($_.FullName)"""
 			& cmd.exe /C $command
 
-			if (Test-Path $($vhdPath.FullName)) {
+            if (Test-Path $($vhdPath.FullName)) {
         		Move-Item "$($vhdPath.FullName)\*.*" $FolderPath
 			} else {
 				Move-Item "$tempPath\*.*" $FolderPath


### PR DESCRIPTION
Currently, the packer's compress post-processor will take the output folder for hyper-v builder and zip that up meaning the "virtual Hard Disk" folder is actually within a subfolder.

This small change will allow the "Expand-Downloads" function to recursively search for the "Virtual hard Disk" folder within the zip and extract it.